### PR TITLE
Update Tofu s3 backend docs

### DIFF
--- a/docs/repository/opentofu.md
+++ b/docs/repository/opentofu.md
@@ -182,7 +182,7 @@ terraform_s3_skip_credentials_validation: "true"
 
 # Tell OpenTofu to use path-style URLs, e.g. <host>/<bucket>, instead of
 # subdomain-style URLs, e.g. <bucket>.<host>
-terraform_s3_force_path_style: "true"
+terraform_s3_use_path_style: "true"
 
 terraform_backend_config:
   endpoint: "{{ terraform_s3_endpoint }}"
@@ -190,7 +190,7 @@ terraform_backend_config:
   bucket: "{{ terraform_s3_bucket }}"
   key: "{{ terraform_s3_key }}"
   skip_credentials_validation: "{{ terraform_s3_skip_credentials_validation }}"
-  force_path_style: "{{ terraform_s3_force_path_style }}"
+  use_path_style: "{{ terraform_s3_use_path_style }}"
   skip_region_validation: "{{ terraform_s3_skip_region_validation }}"  
 ```
 


### PR DESCRIPTION
force_path_style is deprecated in favour of use_path_style in the OpenTofu s3 backend configuration