### PR TITLE
Add optional -q flag to seed ssh script to suppress tofu output

### DIFF
--- a/bin/kube-connect
+++ b/bin/kube-connect
@@ -80,7 +80,7 @@ if [ "$install_mode" = "ha" ]; then
     cluster_name="$(ansible_variable capi_cluster_release_name)"
     kubeconfig_arg="KUBECONFIG=./kubeconfig-${cluster_name}.yaml"
 fi
-"$AZIMUTH_CONFIG_ROOT/bin/seed-ssh" \
+"$AZIMUTH_CONFIG_ROOT/bin/seed-ssh" -q \
   $kubeconfig_arg \
   kubectl config view --raw > "$kubeconfig"
 
@@ -104,7 +104,7 @@ kubectl config rename-context $ctx azimuth --kubeconfig $kubeconfig >/dev/null
 
 # Launch the SOCKS proxy and store the PID
 echo "Starting SOCKS proxy..." >&2
-"$AZIMUTH_CONFIG_ROOT/bin/seed-ssh" -D $socks_port -N &
+"$AZIMUTH_CONFIG_ROOT/bin/seed-ssh" -q -D $socks_port -N &
 socks_pid="$!"
 # Wait a few seconds and check that the process is running
 sleep 5

--- a/bin/seed-ssh
+++ b/bin/seed-ssh
@@ -13,7 +13,6 @@ if [ -z "$AZIMUTH_CONFIG_ROOT" ] || [ -z "$AZIMUTH_CONFIG_ENVIRONMENT_ROOT" ]; t
     exit 1
 fi
 
-
 ansible_variable() {
     ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
     ANSIBLE_STDOUT_CALLBACK=json \
@@ -22,6 +21,15 @@ ansible_variable() {
        jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
 }
 
+tf_init() {
+    ansible_variable terraform_backend_config > "$terraform_dir/backend_config.json"
+    $terraform_binary_path \
+      -chdir="$terraform_dir" \
+      init \
+      -input=false \
+      -reconfigure \
+      -backend-config=$terraform_dir/backend_config.json
+}
 
 # Add the Terraform binary directory to the PATH, so we can use it if it was
 # downloaded as part of a provision
@@ -45,6 +53,16 @@ fi
 work_dir="$(ansible_variable work_directory)/seed-ssh"
 mkdir -p "$work_dir"
 
+# If -q (quiet) is passed to ssh then also suppress terraform / tofu output
+QUIET_MODE=false
+for arg in $@; do
+  if [[ ! $arg == -* ]]; then
+    break
+  elif [[ $arg == "-q" ]]; then
+    QUIET_MODE=true
+  fi
+done
+
 # Initialise the OpenTofu backend
 terraform_backend_type="$(ansible_variable terraform_backend_type)"
 if [ "$terraform_backend_type" = "local" ]; then
@@ -60,13 +78,11 @@ terraform {
   backend "${terraform_backend_type}" {}
 }
 EOF
-    ansible_variable terraform_backend_config > "$terraform_dir/backend_config.json"
-    $terraform_binary_path \
-      -chdir="$terraform_dir" \
-      init \
-      -input=false \
-      -reconfigure \
-      -backend-config=$terraform_dir/backend_config.json
+  if [[ $QUIET_MODE == "true" ]]; then
+    tf_init > /dev/null
+  else
+    tf_init
+  fi
 fi
 
 # Read the required variables from the Terraform state

--- a/bin/seed-ssh
+++ b/bin/seed-ssh
@@ -53,10 +53,14 @@ fi
 work_dir="$(ansible_variable work_directory)/seed-ssh"
 mkdir -p "$work_dir"
 
-# If -q (quiet) is passed to ssh then also suppress terraform / tofu output
+# Check if quiet mode (-q) was passed to SSH command
+# so that we can suppress other output elsewhere too
 QUIET_MODE=false
 for arg in $@; do
   if [[ ! $arg == -* ]]; then
+    # Break if we encounter a non-flag arg since
+    # this is likely a command to run within the SSH
+    # session instead of an arg intended for SSH client
     break
   elif [[ $arg == "-q" ]]; then
     QUIET_MODE=true
@@ -78,6 +82,7 @@ terraform {
   backend "${terraform_backend_type}" {}
 }
 EOF
+  # If -q (quiet) is passed to ssh then also suppress terraform / tofu output
   if [[ $QUIET_MODE == "true" ]]; then
     tf_init > /dev/null
   else


### PR DESCRIPTION
This also allows Tilt dev to work against environments which use remote TF state. Previously, the TF `init` output was being written to the start of the kubeconfig file written by the `kube-connect` script which tilt was trying to use.