### PR TITLE
Skip running dependencies workflow on forks

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   propose_github_release_updates:
     runs-on: ubuntu-latest
+    if: github.repository == 'azimuth-cloud/azimuth-config'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
To avoid the daily spam of:

<img width="495" alt="image" src="https://github.com/user-attachments/assets/39cafc76-bf8d-4299-9398-397a3ff443a6">

(workflow fails to get a token:
<img width="932" alt="image" src="https://github.com/user-attachments/assets/de05ad88-f308-4abd-a2a2-8d787f3692a6">
).