### PR TITLE
Update Magnum CAPI cluster version to 1.29

### DIFF
--- a/environments/capi-mgmt-example/inventory/group_vars/all/variables.yml
+++ b/environments/capi-mgmt-example/inventory/group_vars/all/variables.yml
@@ -33,7 +33,7 @@
 
 # The Kubernetes version that will be used for the HA cluster
 # This should match the image specified image
-# capi_cluster_kubernetes_version: 1.28.11
+# capi_cluster_kubernetes_version: 1.29.11
 
 # The name of the flavor to use for control plane nodes
 # At least 2 CPUs and 8GB RAM is required

--- a/environments/capi-mgmt/inventory/group_vars/all.yml
+++ b/environments/capi-mgmt/inventory/group_vars/all.yml
@@ -24,28 +24,28 @@ infra_flavor_id: >-
 # Upload the Kubernetes image we need for the HA cluster as a private image
 # By default, we get the image from the azimuth-images version
 community_images_default:
-  kube_1_28:
-    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-28-jammy'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-28-jammy'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-28-jammy'].checksum }}"
+  kube_1_29:
+    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].checksum }}"
     source_disk_format: "qcow2"
     container_format: "bare"
-    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-28-jammy'].kubernetes_version }}"
+    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].kubernetes_version }}"
 community_images_default_visibility: private
 community_images_update_existing_visibility: false
 
 capi_cluster_kubernetes_version: >-
   {{-
-    community_images.kube_1_28.kubernetes_version
-    if community_images is defined and 'kube_1_28' in community_images
+    community_images.kube_1_29.kubernetes_version
+    if community_images is defined and 'kube_1_29' in community_images
     else undef(hint = 'capi_cluster_kubernetes_version is required')
   }}
 capi_cluster_machine_image_id: >-
   {{-
-    community_images_image_ids.kube_1_28
+    community_images_image_ids.kube_1_29
     if (
       community_images_image_ids is defined and
-      'kube_1_28' in community_images_image_ids
+      'kube_1_29' in community_images_image_ids
     )
     else undef(hint = 'capi_cluster_machine_image_id is required')
   }}


### PR DESCRIPTION
We should probably try to figure out a better way to keep this in sync with the default in the `capi_cluster` azimuth-ops role. I think the reason Tyler originally structured the config this way was to allow us to override the community images to only upload a single private images for the management cluster. I'll see if I can come up with a better way to structure the config, but in the mean time we need to get the k8s version back up to speed with the azimuth-ops version (1.30 currently) within the constraints of our monthly release cadence and the k8s version skew policy.