### PR TITLE
Pin firefox to extended support release in test runner setup script

### DIFF
--- a/bin/ci-setup
+++ b/bin/ci-setup
@@ -49,7 +49,7 @@ else
 fi
 
 run_apt update
-run_apt install -y -t 'o=LP-PPA-mozillateam' firefox
+run_apt install -y -t 'o=LP-PPA-mozillateam' firefox-esr
 
 pip install -U pip
 pip install -r requirements.txt


### PR DESCRIPTION
This only seems to be used in downstream GitLab CI workflow samples rather than in our upstream GitHub CI workflows so was missed as part of #211.