### PR TITLE
Update CAPI mgmt k8s version to 1.30

### DIFF
--- a/environments/capi-mgmt-example/inventory/group_vars/all/variables.yml
+++ b/environments/capi-mgmt-example/inventory/group_vars/all/variables.yml
@@ -33,7 +33,7 @@
 
 # The Kubernetes version that will be used for the HA cluster
 # This should match the image specified image
-# capi_cluster_kubernetes_version: 1.29.11
+# capi_cluster_kubernetes_version: 1.30.12
 
 # The name of the flavor to use for control plane nodes
 # At least 2 CPUs and 8GB RAM is required

--- a/environments/capi-mgmt/inventory/group_vars/all.yml
+++ b/environments/capi-mgmt/inventory/group_vars/all.yml
@@ -24,28 +24,28 @@ infra_flavor_id: >-
 # Upload the Kubernetes image we need for the HA cluster as a private image
 # By default, we get the image from the azimuth-images version
 community_images_default:
-  kube_1_29:
-    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].name }}"
-    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].url }}"
-    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].checksum }}"
+  kube_1_30:
+    name: "{{ community_images_azimuth_images_manifest['kubernetes-1-30-jammy'].name }}"
+    source_url: "{{ community_images_azimuth_images_manifest['kubernetes-1-30-jammy'].url }}"
+    checksum: "{{ community_images_azimuth_images_manifest['kubernetes-1-30-jammy'].checksum }}"
     source_disk_format: "qcow2"
     container_format: "bare"
-    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-29-jammy'].kubernetes_version }}"
+    kubernetes_version: "{{ community_images_azimuth_images_manifest['kubernetes-1-30-jammy'].kubernetes_version }}"
 community_images_default_visibility: private
 community_images_update_existing_visibility: false
 
 capi_cluster_kubernetes_version: >-
   {{-
-    community_images.kube_1_29.kubernetes_version
-    if community_images is defined and 'kube_1_29' in community_images
+    community_images.kube_1_30.kubernetes_version
+    if community_images is defined and 'kube_1_30' in community_images
     else undef(hint = 'capi_cluster_kubernetes_version is required')
   }}
 capi_cluster_machine_image_id: >-
   {{-
-    community_images_image_ids.kube_1_29
+    community_images_image_ids.kube_1_30
     if (
       community_images_image_ids is defined and
-      'kube_1_29' in community_images_image_ids
+      'kube_1_30' in community_images_image_ids
     )
     else undef(hint = 'capi_cluster_machine_image_id is required')
   }}


### PR DESCRIPTION
We're still 1 version behind azimuth-ops default but need to bump versions sequentially so this will have to do for now. See [previous PR](https://github.com/azimuth-cloud/azimuth-config/pull/201) for more context.