### PR TITLE
Set coral-credits release_namespace to azimuth

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -75,7 +75,7 @@ settings = deep_merge(
                 "release_namespace": "azimuth",
             },
             "coral-credits": {
-                "release_namespace": "coral-credits",
+                "release_namespace": "azimuth",
             },
             "cluster-api-addon-provider": {
                 "release_namespace": "capi-addon-system",


### PR DESCRIPTION
Coral-credits is installed into the azimuth namespace by the role default in ansible-collection-azimuth-ops [1].

I think it _probably_ belongs in the `coral-credits` namespace, as its not strictly an Azimuth component, and Azimuth does not talk to it directly, but it has been deployed on some clouds already (in the Azimuth namespace), so changing this side is probably less friction.

[1] https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/blob/cb06aa7e6011ea1871965f9691ede7c5e7c9bb88/roles/coral_credits/defaults/main.yml#L9